### PR TITLE
おけるマスにハイライト

### DIFF
--- a/app/src/components/features/board/BoardContainer.tsx
+++ b/app/src/components/features/board/BoardContainer.tsx
@@ -1,5 +1,7 @@
 import { BoardPresenter } from "@/components/features/board/BoardPresenter";
+import { Disc, DiscType } from "@/domains/reversi/const";
 import { ReversiGameType } from "@/hooks/reversiGame";
+import { useSkills } from "@/hooks/reversiSkill";
 
 type BoardContainerProps = {
   reversiGame: ReversiGameType;
@@ -9,6 +11,6 @@ export function BoardContainer({ reversiGame }: BoardContainerProps) {
   const handleClick = (row: number, col: number) => {
     reversiGame.makeMove(row, col);
   };
-
-  return <BoardPresenter reversiGame={reversiGame} handleClick={handleClick} />;
+  const {skills} = useSkills();
+  return <BoardPresenter reversiGame={reversiGame} isHighlightActive={skills[reversiGame.currentPlayer as Exclude<DiscType, undefined>].highlight} handleClick={handleClick} />;
 }

--- a/app/src/components/features/board/BoardContainer.tsx
+++ b/app/src/components/features/board/BoardContainer.tsx
@@ -1,5 +1,5 @@
 import { BoardPresenter } from "@/components/features/board/BoardPresenter";
-import { Disc, DiscType } from "@/domains/reversi/const";
+import { DiscType } from "@/domains/reversi/const";
 import { ReversiGameType } from "@/hooks/reversiGame";
 import { useSkills } from "@/hooks/reversiSkill";
 
@@ -11,6 +11,15 @@ export function BoardContainer({ reversiGame }: BoardContainerProps) {
   const handleClick = (row: number, col: number) => {
     reversiGame.makeMove(row, col);
   };
-  const {skills} = useSkills();
-  return <BoardPresenter reversiGame={reversiGame} isHighlightActive={skills[reversiGame.currentPlayer as Exclude<DiscType, undefined>].highlight} handleClick={handleClick} />;
+  const { skills } = useSkills();
+  return (
+    <BoardPresenter
+      reversiGame={reversiGame}
+      isHighlightActive={
+        skills[reversiGame.currentPlayer as Exclude<DiscType, undefined>]
+          .highlight
+      }
+      handleClick={handleClick}
+    />
+  );
 }

--- a/app/src/components/features/board/BoardPresenter.tsx
+++ b/app/src/components/features/board/BoardPresenter.tsx
@@ -33,7 +33,7 @@ export function BoardPresenter({
               key={String(`board-${i}-${j}`)}
               disc={reversiGame.board[i][j]}
               isMakeable={reversiGame.checkMakeable(i, j)}
-              isHighlight = {reversiGame.checkMakeable(i,j) && isHighlightActive}
+              isHighlight={reversiGame.checkMakeable(i, j) && isHighlightActive}
               onClick={() => handleClick(i, j)}
             />
           ))}

--- a/app/src/components/features/board/BoardPresenter.tsx
+++ b/app/src/components/features/board/BoardPresenter.tsx
@@ -3,11 +3,13 @@ import { ReversiGameType } from "@/hooks/reversiGame";
 
 type BoardPresenterProps = {
   reversiGame: ReversiGameType;
+  isHighlightActive: boolean;
   handleClick: (row: number, col: number) => void;
 };
 
 export function BoardPresenter({
   reversiGame,
+  isHighlightActive,
   handleClick,
 }: BoardPresenterProps) {
   return (
@@ -31,6 +33,7 @@ export function BoardPresenter({
               key={String(`board-${i}-${j}`)}
               disc={reversiGame.board[i][j]}
               isMakeable={reversiGame.checkMakeable(i, j)}
+              isHighlight = {reversiGame.checkMakeable(i,j) && isHighlightActive}
               onClick={() => handleClick(i, j)}
             />
           ))}

--- a/app/src/components/features/board/ui/CellPresenter.tsx
+++ b/app/src/components/features/board/ui/CellPresenter.tsx
@@ -28,7 +28,9 @@ export function CellPresenter({
   const hoverClass = isMakeable
     ? `hover:bg-gray-500 hover:opacity-50 cursor-pointer`
     : "";
-  const highlightClass = isHighlight ? "cellhighlight" : "";
+  const highlightClass = isHighlight
+    ? "      border-4 border-yellow-300 border-opacity-50 shadow-[inset_0_0_5px_3px_rgba(255,215,0,0.9)]"
+    : "";
 
   return (
     <div

--- a/app/src/components/features/board/ui/CellPresenter.tsx
+++ b/app/src/components/features/board/ui/CellPresenter.tsx
@@ -26,10 +26,11 @@ export function CellPresenter({
   const hoverClass = isMakeable
     ? `hover:bg-gray-500 hover:opacity-50 cursor-pointer`
     : "";
+  const highlightClass = isMakeable ? "cellhighlight" : "";
 
   return (
     <div
-      className="border border-black w-20 h-20 bg-green-800 flex items-center justify-center"
+      className={`border border-black w-20 h-20 bg-green-800 flex items-center justify-center ${highlightClass}`}
       onClick={onClick}
       onKeyPress={onClick}
       tabIndex={0}

--- a/app/src/components/features/board/ui/CellPresenter.tsx
+++ b/app/src/components/features/board/ui/CellPresenter.tsx
@@ -14,19 +14,21 @@ const viewDisc = (disc: DiscType) => {
 type CellPresenterProps = {
   disc: DiscType;
   isMakeable: boolean;
+  isHighlight: boolean;
   onClick: () => void;
 };
 
 export function CellPresenter({
   disc,
   isMakeable,
+  isHighlight,
   onClick,
 }: CellPresenterProps) {
   const discClass = viewDisc(disc);
   const hoverClass = isMakeable
     ? `hover:bg-gray-500 hover:opacity-50 cursor-pointer`
     : "";
-  const highlightClass = isMakeable ? "cellhighlight" : "";
+  const highlightClass =isHighlight ? "cellhighlight" : "";
 
   return (
     <div

--- a/app/src/components/features/board/ui/CellPresenter.tsx
+++ b/app/src/components/features/board/ui/CellPresenter.tsx
@@ -28,7 +28,7 @@ export function CellPresenter({
   const hoverClass = isMakeable
     ? `hover:bg-gray-500 hover:opacity-50 cursor-pointer`
     : "";
-  const highlightClass =isHighlight ? "cellhighlight" : "";
+  const highlightClass = isHighlight ? "cellhighlight" : "";
 
   return (
     <div

--- a/app/src/components/features/board/ui/skillToggle.tsx
+++ b/app/src/components/features/board/ui/skillToggle.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { DiscType, Disc } from '@/domains/reversi/const';
+import { useSkills } from '@/hooks/reversiSkill';
+
+const SkillToggleButton = ({ user, skillName }: { user: Exclude<DiscType, undefined>; skillName: string }) => {
+  const { toggleSkill } = useSkills();
+
+  return (
+    <button onClick={() => toggleSkill(user, skillName)}
+          className="border border-black rounded p-2"
+    >
+      Toggle {skillName} for {user}
+    </button>
+  );
+};
+
+export default SkillToggleButton;

--- a/app/src/components/features/board/ui/skillToggle.tsx
+++ b/app/src/components/features/board/ui/skillToggle.tsx
@@ -1,13 +1,19 @@
-import React from 'react';
-import { DiscType, Disc } from '@/domains/reversi/const';
-import { useSkills } from '@/hooks/reversiSkill';
+import { DiscType } from "@/domains/reversi/const";
+import { useSkills } from "@/hooks/reversiSkill";
 
-const SkillToggleButton = ({ user, skillName }: { user: Exclude<DiscType, undefined>; skillName: string }) => {
+const SkillToggleButton = ({
+  user,
+  skillName,
+}: {
+  user: Exclude<DiscType, undefined>;
+  skillName: string;
+}) => {
   const { toggleSkill } = useSkills();
 
   return (
-    <button onClick={() => toggleSkill(user, skillName)}
-          className="border border-black rounded p-2"
+    <button
+      onClick={() => toggleSkill(user, skillName)}
+      className="border border-black rounded p-2"
     >
       Toggle {skillName} for {user}
     </button>

--- a/app/src/components/features/board/ui/skillToggle.tsx
+++ b/app/src/components/features/board/ui/skillToggle.tsx
@@ -1,23 +1,24 @@
 import { DiscType } from "@/domains/reversi/const";
 import { useSkills } from "@/hooks/reversiSkill";
 
-const SkillToggleButton = ({
+function SkillToggleButton({
   user,
   skillName,
 }: {
   user: Exclude<DiscType, undefined>;
   skillName: string;
-}) => {
+}) {
   const { toggleSkill } = useSkills();
 
   return (
     <button
+      type="button" // Add the type attribute
       onClick={() => toggleSkill(user, skillName)}
       className="border border-black rounded p-2"
     >
       Toggle {skillName} for {user}
     </button>
   );
-};
+}
 
 export default SkillToggleButton;

--- a/app/src/components/features/game/GamePresenter.tsx
+++ b/app/src/components/features/game/GamePresenter.tsx
@@ -1,7 +1,7 @@
 import { BoardContainer } from "@/components/features/board/BoardContainer";
+import SkillToggleButton from "@/components/features/board/ui/skillToggle";
 import { Disc } from "@/domains/reversi/const";
 import { ReversiGameType } from "@/hooks/reversiGame";
-import SkillToggleButton from "../board/ui/skillToggle";
 
 type GamePresenterProps = {
   reversiGame: ReversiGameType;

--- a/app/src/components/features/game/GamePresenter.tsx
+++ b/app/src/components/features/game/GamePresenter.tsx
@@ -1,6 +1,8 @@
 import { BoardContainer } from "@/components/features/board/BoardContainer";
-import { Disc } from "@/domains/reversi/const";
+import { Disc, DiscType } from "@/domains/reversi/const";
 import { ReversiGameType } from "@/hooks/reversiGame";
+import { useSkills } from "@/hooks/reversiSkill";
+import SkillToggleButton from "../board/ui/skillToggle";
 
 type GamePresenterProps = {
   reversiGame: ReversiGameType;
@@ -33,6 +35,8 @@ export function GamePresenter({ reversiGame }: GamePresenterProps) {
         >
           Reset
         </button>
+        <SkillToggleButton user={Disc.white} skillName="highlight" />
+        <SkillToggleButton user={Disc.black} skillName="highlight" />
       </div>
     </div>
   );

--- a/app/src/components/features/game/GamePresenter.tsx
+++ b/app/src/components/features/game/GamePresenter.tsx
@@ -1,7 +1,6 @@
 import { BoardContainer } from "@/components/features/board/BoardContainer";
-import { Disc, DiscType } from "@/domains/reversi/const";
+import { Disc } from "@/domains/reversi/const";
 import { ReversiGameType } from "@/hooks/reversiGame";
-import { useSkills } from "@/hooks/reversiSkill";
 import SkillToggleButton from "../board/ui/skillToggle";
 
 type GamePresenterProps = {

--- a/app/src/components/pages/Top.tsx
+++ b/app/src/components/pages/Top.tsx
@@ -1,5 +1,11 @@
 import { GameContainer } from "@/components/features/game/GameContainer";
+import { SkillProvider } from "@/hooks/reversiSkill";
 
-export function Top() {
-  return <GameContainer />;
+export function Top()
+{
+  return(
+    <SkillProvider>
+      <GameContainer />
+    </SkillProvider>
+  );
 }

--- a/app/src/hooks/reversiSkill.tsx
+++ b/app/src/hooks/reversiSkill.tsx
@@ -1,5 +1,11 @@
-import React, { createContext, useContext, useState, ReactNode, useCallback } from 'react';
-import { DiscType, Disc } from '@/domains/reversi/const';
+import React, {
+  createContext,
+  useContext,
+  useState,
+  ReactNode,
+  useCallback,
+} from "react";
+import { DiscType, Disc } from "@/domains/reversi/const";
 
 type SkillState = {
   [user: Exclude<DiscType, undefined>]: {
@@ -12,36 +18,40 @@ type SkillContextType = {
   toggleSkill: (user: Exclude<DiscType, undefined>, skillName: string) => void;
 };
 
-const SkillContext = createContext<SkillContextType>({ skills: {}, toggleSkill: () => {} });
+const SkillContext = createContext<SkillContextType>({
+  skills: {},
+  toggleSkill: () => {},
+});
 
 export const SkillProvider = ({ children }: { children: ReactNode }) => {
   const [skills, setSkills] = useState<SkillState>({
     [Disc.black]: {},
-    [Disc.white]: {}
+    [Disc.white]: {},
   });
 
-  const toggleSkill = useCallback((user: Exclude<DiscType, undefined>, skillName: string) => {
-    setSkills((prevSkills) => ({
-      ...prevSkills,
-      [user]: {
-        ...prevSkills[user],
-        [skillName]: !prevSkills[user]?.[skillName],
-      },
-    }));
-  }, []);
+  const toggleSkill = useCallback(
+    (user: Exclude<DiscType, undefined>, skillName: string) => {
+      setSkills((prevSkills) => ({
+        ...prevSkills,
+        [user]: {
+          ...prevSkills[user],
+          [skillName]: !prevSkills[user]?.[skillName],
+        },
+      }));
+    },
+    [],
+  );
   return (
     <SkillContext.Provider value={{ skills, toggleSkill }}>
       {children}
     </SkillContext.Provider>
-  
   );
-
 };
 
 export const useSkills = () => {
   const context = useContext(SkillContext);
   if (!context) {
-    throw new Error('useSkills must be used within a SkillProvider');
+    throw new Error("useSkills must be used within a SkillProvider");
   }
   return context;
 };

--- a/app/src/hooks/reversiSkill.tsx
+++ b/app/src/hooks/reversiSkill.tsx
@@ -4,7 +4,9 @@ import React, {
   useState,
   ReactNode,
   useCallback,
+  useMemo,
 } from "react";
+
 import { DiscType, Disc } from "@/domains/reversi/const";
 
 type SkillState = {
@@ -23,7 +25,7 @@ const SkillContext = createContext<SkillContextType>({
   toggleSkill: () => {},
 });
 
-export const SkillProvider = ({ children }: { children: ReactNode }) => {
+export function SkillProvider({ children }: { children: ReactNode }) {
   const [skills, setSkills] = useState<SkillState>({
     [Disc.black]: {},
     [Disc.white]: {},
@@ -41,17 +43,17 @@ export const SkillProvider = ({ children }: { children: ReactNode }) => {
     },
     [],
   );
-  return (
-    <SkillContext.Provider value={{ skills, toggleSkill }}>
-      {children}
-    </SkillContext.Provider>
+  return useMemo(
+    () => (
+      <SkillContext.Provider value={{ skills, toggleSkill }}>
+        {children}
+      </SkillContext.Provider>
+    ),
+    [skills, toggleSkill],
   );
-};
+}
 
 export const useSkills = () => {
   const context = useContext(SkillContext);
-  if (!context) {
-    throw new Error("useSkills must be used within a SkillProvider");
-  }
   return context;
 };

--- a/app/src/hooks/reversiSkill.tsx
+++ b/app/src/hooks/reversiSkill.tsx
@@ -1,0 +1,47 @@
+import React, { createContext, useContext, useState, ReactNode, useCallback } from 'react';
+import { DiscType, Disc } from '@/domains/reversi/const';
+
+type SkillState = {
+  [user: Exclude<DiscType, undefined>]: {
+    [skillName: string]: boolean;
+  };
+};
+
+type SkillContextType = {
+  skills: SkillState;
+  toggleSkill: (user: Exclude<DiscType, undefined>, skillName: string) => void;
+};
+
+const SkillContext = createContext<SkillContextType>({ skills: {}, toggleSkill: () => {} });
+
+export const SkillProvider = ({ children }: { children: ReactNode }) => {
+  const [skills, setSkills] = useState<SkillState>({
+    [Disc.black]: {},
+    [Disc.white]: {}
+  });
+
+  const toggleSkill = useCallback((user: Exclude<DiscType, undefined>, skillName: string) => {
+    setSkills((prevSkills) => ({
+      ...prevSkills,
+      [user]: {
+        ...prevSkills[user],
+        [skillName]: !prevSkills[user]?.[skillName],
+      },
+    }));
+  }, []);
+  return (
+    <SkillContext.Provider value={{ skills, toggleSkill }}>
+      {children}
+    </SkillContext.Provider>
+  
+  );
+
+};
+
+export const useSkills = () => {
+  const context = useContext(SkillContext);
+  if (!context) {
+    throw new Error('useSkills must be used within a SkillProvider');
+  }
+  return context;
+};

--- a/app/src/index.css
+++ b/app/src/index.css
@@ -6,3 +6,8 @@
 body {
   font-family: "Noto Sans JP", sans-serif;
 }
+
+.cellhighlight {
+  border: 4px solid rgba(255, 215, 0, 0.5); /* 枠線 */
+  box-shadow: inset 0 0 5px 3px rgba(255, 215, 0, 0.9); /* 内側に輝き */
+}

--- a/app/src/index.css
+++ b/app/src/index.css
@@ -6,8 +6,3 @@
 body {
   font-family: "Noto Sans JP", sans-serif;
 }
-
-.cellhighlight {
-  border: 4px solid rgba(255, 215, 0, 0.5); /* 枠線 */
-  box-shadow: inset 0 0 5px 3px rgba(255, 215, 0, 0.9); /* 内側に輝き */
-}


### PR DESCRIPTION
isMakeableによって判定わけてますが
将来的にスキルOnによって切り替わるようにするべき
このPRはどこまでやりましょう？
置けるマスにハイライト機能実装
![image](https://github.com/silenvx/reversi/assets/37147114/446d35f5-794f-41c5-96a8-78cfeca6589e)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - リバーシゲームにスキルハイライト機能を追加。
  - `SkillToggleButton`コンポーネントを導入し、ユーザーがスキルをトグルできるように。

- **改善**
  - ゲームボードでスキルハイライトを適用するためのプロパティを追加。
  - セルコンポーネントのハイライトクラスを条件付きで適用。

- **構造変更**
  - `SkillProvider`コンポーネントを追加し、スキルの管理とコンテキスト提供を実装。
  - `useSkills`カスタムフックを追加し、スキルコンテキストにアクセス可能に。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->