### PR TITLE
ハイライトスキルのバグ修正

### DIFF
--- a/app/src/components/features/board/BoardContainer.tsx
+++ b/app/src/components/features/board/BoardContainer.tsx
@@ -24,7 +24,7 @@ export function BoardContainer({ reversiGame }: BoardContainerProps) {
       reversiGame={reversiGame}
       isHighlightActive={
         skills[reversiGame.currentPlayer as Exclude<DiscType, undefined>]
-          .highlight
+          .highLight
       }
       handleClick={handleClick}
     />

--- a/app/src/hooks/reversiSkill.tsx
+++ b/app/src/hooks/reversiSkill.tsx
@@ -11,7 +11,7 @@ import { DiscType, Disc, SkillStateType } from "@/domains/reversi/const";
 
 type SkillState = {
   [user: Exclude<DiscType, undefined>]: {
-    [skillName: string]: boolean;
+    [skillName: SkillStateType]: boolean;
   };
 };
 
@@ -35,7 +35,7 @@ export function SkillProvider({ children }: { children: ReactNode }) {
   });
 
   const toggleSkill = useCallback(
-    (user: Exclude<DiscType, undefined>, skillName: string) => {
+    (user: Exclude<DiscType, undefined>, skillName: SkillStateType) => {
       setSkills((prevSkills) => ({
         ...prevSkills,
         [user]: {


### PR DESCRIPTION
skill を　string から typeに変えた際に修正漏れがあったので動作していなかった。

修正漏れをすべて修正

![reversiHighLight](https://github.com/silenvx/reversi/assets/37147114/c8039375-0e69-4ccd-9469-3f5b232b8e97)

