### PR TITLE
fix: デザイン崩れ修正

### DIFF
--- a/app/src/components/features/board/BoardPresenter.tsx
+++ b/app/src/components/features/board/BoardPresenter.tsx
@@ -13,20 +13,18 @@ export function BoardPresenter({
   handleClick,
 }: BoardPresenterProps) {
   return (
-    <div>
-      <div className="grid w-96 grid-cols-8 grid-rows-8">
-        {reversiGame.board.map((row, i) =>
-          row.map((_, j) => (
-            <CellPresenter
-              key={String(`board-${i}-${j}`)}
-              disc={reversiGame.board[i][j]}
-              isMakeable={reversiGame.checkMakeable(i, j)}
-              isHighlight={reversiGame.checkMakeable(i, j) && isHighlightActive}
-              onClick={() => handleClick(i, j)}
-            />
-          )),
-        )}
-      </div>
+    <div className="grid h-full grid-cols-8 grid-rows-8">
+      {reversiGame.board.map((row, i) =>
+        row.map((_, j) => (
+          <CellPresenter
+            key={String(`board-${i}-${j}`)}
+            disc={reversiGame.board[i][j]}
+            isMakeable={reversiGame.checkMakeable(i, j)}
+            isHighlight={reversiGame.checkMakeable(i, j) && isHighlightActive}
+            onClick={() => handleClick(i, j)}
+          />
+        )),
+      )}
     </div>
   );
 }

--- a/app/src/components/features/game/GamePresenter.tsx
+++ b/app/src/components/features/game/GamePresenter.tsx
@@ -13,20 +13,25 @@ export function GamePresenter({ reversiGame }: GamePresenterProps) {
   return (
     <div className="flex h-screen justify-center bg-indigo-950 p-8">
       <div className="flex w-full flex-col justify-between">
-        <PlayerInformationContainer
-          reversiGame={reversiGame}
-          player={Disc.black}
-        />
-        <div className="flex w-full justify-center gap-4">
-          <MenuContainer reversiGame={reversiGame} />
-          <BoardContainer reversiGame={reversiGame} />
-          {/* TODO: GaugeContainerのvalueは仮の値 */}
-          <GaugeContainer value={reversiGame.boardEvaluatedScore} />
+        <div className="h-1/5">
+          <PlayerInformationContainer
+            reversiGame={reversiGame}
+            player={Disc.black}
+          />
         </div>
-        <PlayerInformationContainer
-          reversiGame={reversiGame}
-          player={Disc.white}
-        />
+        <div className="flex h-3/5 w-full">
+          <div className="flex h-full w-full flex-grow justify-center gap-4 p-[5%]">
+            <MenuContainer reversiGame={reversiGame} />
+            <BoardContainer reversiGame={reversiGame} />
+            <GaugeContainer value={reversiGame.boardEvaluatedScore} />
+          </div>
+        </div>
+        <div className="h-1/5">
+          <PlayerInformationContainer
+            reversiGame={reversiGame}
+            player={Disc.white}
+          />
+        </div>
       </div>
     </div>
   );

--- a/app/src/components/features/gauge/GaugePresenter.tsx
+++ b/app/src/components/features/gauge/GaugePresenter.tsx
@@ -25,5 +25,5 @@ type GaugePresenterProps = {
 export function GaugePresenter({ value }: GaugePresenterProps) {
   // 縦のバーを表示する
   // tailwindの計算が動的にはうまく動かないのでstyleを直接指定
-  return <div className="h-96 w-6 rounded-full" style={gaugeStyle(value)} />;
+  return <div className="h-full w-6 rounded-full" style={gaugeStyle(value)} />;
 }

--- a/app/src/components/features/menu/MenuContainer.tsx
+++ b/app/src/components/features/menu/MenuContainer.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 
 import { MenuPresenter } from "@/components/features/menu/MenuPresenter";
+import { useHandContext } from "@/hooks/handContext";
 import { ReversiGameType } from "@/hooks/reversiGame";
 
 type MenuContainerProps = {
@@ -8,14 +9,17 @@ type MenuContainerProps = {
 };
 
 export function MenuContainer({ reversiGame }: MenuContainerProps) {
+  const { resetCard } = useHandContext();
+
   const [modalOpenSetting, setModalOpenSetting] = useState(false);
   const [modalOpenHint, setModalOpenHint] = useState(false);
+  const [modalOpenReset, setModalOpenReset] = useState(false);
 
   const handleClickSetting = () => {
     setModalOpenSetting(true);
   };
 
-  const handleClickClose = () => {
+  const handleClickCloseSetting = () => {
     setModalOpenSetting(false);
   };
 
@@ -26,15 +30,31 @@ export function MenuContainer({ reversiGame }: MenuContainerProps) {
   const handleClickCloseHint = () => {
     setModalOpenHint(false);
   };
+
+  const handleClickReset = () => {
+    reversiGame.reset();
+    resetCard();
+    setModalOpenReset(false);
+  };
+  const handleClickOpenReset = () => {
+    setModalOpenReset(true);
+  };
+  const handleClickCloseReset = () => {
+    setModalOpenReset(false);
+  };
   return (
     <MenuPresenter
       reversiGame={reversiGame}
       handleClickSetting={handleClickSetting}
-      handleClickClose={handleClickClose}
+      handleClickCloseSetting={handleClickCloseSetting}
       modalOpenSetting={modalOpenSetting}
       modalOpenHint={modalOpenHint}
       handleClickHint={handleClickHint}
       handleClickCloseHint={handleClickCloseHint}
+      modalOpenReset={modalOpenReset}
+      handleClickReset={handleClickReset}
+      handleClickOpenReset={handleClickOpenReset}
+      handleClickCloseReset={handleClickCloseReset}
     />
   );
 }

--- a/app/src/components/features/menu/MenuPresenter.tsx
+++ b/app/src/components/features/menu/MenuPresenter.tsx
@@ -6,27 +6,36 @@ import { TfiReload } from "react-icons/tfi";
 import SkillToggleButton from "@/components/features/board/ui/skillToggle";
 import { HintPresenter } from "@/components/features/hint/HintPresenter";
 import { MenuModal } from "@/components/features/menu/MenuModal";
+import { ModalMenuReset } from "@/components/features/menu/ui/MenuResetModal";
 import { Disc } from "@/domains/reversi/const";
 import { ReversiGameType } from "@/hooks/reversiGame";
 
 type MenuPresenterProps = {
   reversiGame: ReversiGameType;
   handleClickSetting: () => void;
-  handleClickClose: () => void;
+  handleClickCloseSetting: () => void;
   modalOpenSetting: boolean;
   modalOpenHint: boolean;
   handleClickHint: () => void;
   handleClickCloseHint: () => void;
+  modalOpenReset: boolean;
+  handleClickReset: () => void;
+  handleClickOpenReset: () => void;
+  handleClickCloseReset: () => void;
 };
 
 export function MenuPresenter({
   reversiGame,
   handleClickSetting,
-  handleClickClose,
+  handleClickCloseSetting,
   modalOpenSetting,
   modalOpenHint,
   handleClickHint,
   handleClickCloseHint,
+  modalOpenReset,
+  handleClickReset,
+  handleClickOpenReset,
+  handleClickCloseReset,
 }: MenuPresenterProps) {
   return (
     <>
@@ -38,10 +47,12 @@ export function MenuPresenter({
         <button type="button" aria-label="Setting" onClick={handleClickSetting}>
           <GoGear />
         </button>
-        <TfiReload />
+        <button type="button" aria-label="Reset" onClick={handleClickOpenReset}>
+          <TfiReload />
+        </button>
       </div>
       {modalOpenSetting && (
-        <MenuModal handleClickClose={handleClickClose}>
+        <MenuModal handleClickClose={handleClickCloseSetting}>
           <div className="flex h-auto max-h-screen w-full cursor-default flex-col gap-5 rounded-md bg-white p-10 shadow-md">
             <button
               className="rounded border border-black p-2"
@@ -57,6 +68,12 @@ export function MenuPresenter({
       )}
       {modalOpenHint && (
         <HintPresenter handleClickClose={handleClickCloseHint} />
+      )}
+      {modalOpenReset && (
+        <ModalMenuReset
+          handleClickClose={handleClickCloseReset}
+          handleClickReset={handleClickReset}
+        />
       )}
     </>
   );

--- a/app/src/components/features/menu/ui/MenuResetModal.tsx
+++ b/app/src/components/features/menu/ui/MenuResetModal.tsx
@@ -1,0 +1,46 @@
+import { MenuModal } from "@/components/features/menu/MenuModal";
+
+type ModalMenuResetProps = {
+  handleClickClose: () => void;
+  handleClickReset: () => void;
+};
+
+export function ModalMenuReset({
+  handleClickClose,
+  handleClickReset,
+}: ModalMenuResetProps) {
+  const neonTextShadow = {
+    textShadow:
+      "0 0 5px #ff8c00, 0 0 10px #ff8c00, 0 0 20px #ff8c00, 0 0 40px #ff8c00",
+  };
+
+  return (
+    <MenuModal handleClickClose={handleClickClose}>
+      <div
+        className="flex flex-col gap-4 rounded border bg-black p-4 text-white shadow-lg"
+        style={neonTextShadow}
+      >
+        <h1 className="text-xl" style={neonTextShadow}>
+          リセット
+        </h1>
+        <p>リセットしますか？</p>
+        <div className="flex gap-2">
+          <button
+            className="rounded border border-white border-opacity-50 p-2 hover:border-opacity-100"
+            onClick={handleClickClose}
+            type="button"
+          >
+            <p style={neonTextShadow}>キャンセル</p>
+          </button>
+          <button
+            className="rounded border border-orange-500 border-opacity-50 p-2 hover:border-opacity-100"
+            onClick={handleClickReset}
+            type="button"
+          >
+            <p style={neonTextShadow}>リセットする</p>
+          </button>
+        </div>
+      </div>
+    </MenuModal>
+  );
+}

--- a/app/src/components/features/playerInformation/PlayerInformationPresenter.tsx
+++ b/app/src/components/features/playerInformation/PlayerInformationPresenter.tsx
@@ -15,7 +15,7 @@ export function PlayerInformationPresenter({
   const rotateClass = player === Disc.black ? "rotate-180" : "";
 
   return (
-    <div className={`flex flex-row gap-10 ${rotateClass}`}>
+    <div className={`flex h-full flex-row gap-10 ${rotateClass}`}>
       <ScoreContainer reversiGame={reversiGame} player={player} />
       <HandContainer reversiGame={reversiGame} player={player} />
     </div>

--- a/app/src/hooks/deck.ts
+++ b/app/src/hooks/deck.ts
@@ -42,5 +42,7 @@ export const useDeck = () => {
     },
     [cards],
   );
-  return { cards, drawCard };
+
+  const resetDeck = () => setCards(cardlist);
+  return { cards, drawCard, resetDeck };
 };

--- a/app/src/hooks/deckContext.tsx
+++ b/app/src/hooks/deckContext.tsx
@@ -12,13 +12,17 @@ import { useDeck } from "@/hooks/deck";
 interface DeckContextType {
   deck: SkillCard[];
   drawCard: (adv: number) => SkillCard | null;
+  resetDeck: () => void;
 }
 
 const DeckContext = createContext<DeckContextType | undefined>(undefined);
 
 export function DeckProvider({ children }: { children: ReactNode }) {
-  const { cards, drawCard } = useDeck();
-  const value = useMemo(() => ({ deck: cards, drawCard }), [cards, drawCard]);
+  const { cards, drawCard, resetDeck } = useDeck();
+  const value = useMemo(
+    () => ({ deck: cards, drawCard, resetDeck }),
+    [cards, drawCard],
+  );
   return <DeckContext.Provider value={value}>{children}</DeckContext.Provider>;
 }
 

--- a/app/src/hooks/hand.ts
+++ b/app/src/hooks/hand.ts
@@ -10,7 +10,7 @@ import { useDeckContext } from "@/hooks/deckContext";
  * @returns {{ blackHands: any; whiteHands: any; drawCardForPlayer: any; playCard: any; }}
  */
 export const useHands = () => {
-  const { drawCard } = useDeckContext();
+  const { drawCard, resetDeck } = useDeckContext();
   const [blackHands, setBlackHands] = useState<SkillCard[]>([]);
   const [whiteHands, setWhiteHands] = useState<SkillCard[]>([]);
 
@@ -56,6 +56,12 @@ export const useHands = () => {
     [blackHands, whiteHands],
   );
 
+  const resetCard = () => {
+    setBlackHands([]);
+    setWhiteHands([]);
+    resetDeck();
+  };
+
   /**
    * ユーザーがカードをプレイする
    * @param {DiscType} player ユーザー
@@ -64,5 +70,12 @@ export const useHands = () => {
    * @type {*}
    */
 
-  return { blackHands, whiteHands, drawCardForPlayer, discardCard, addCard };
+  return {
+    blackHands,
+    whiteHands,
+    drawCardForPlayer,
+    discardCard,
+    addCard,
+    resetCard,
+  };
 };

--- a/app/src/hooks/handContext.tsx
+++ b/app/src/hooks/handContext.tsx
@@ -16,6 +16,7 @@ export interface HandContextType {
   drawCardForPlayer: (player: DiscType, score: number) => void;
   discardCard: (player: DiscType, cardId: string) => void;
   addCard: (player: DiscType, card: SkillCard) => void;
+  resetCard: () => void;
 }
 
 const HandContext = createContext<HandContextType | undefined>(undefined);


### PR DESCRIPTION
プレイ中にデザイン崩れしていたのを修正しました
ipadサイズ
![localhost_3000_reversi_(iPad Mini)](https://github.com/user-attachments/assets/eb32e709-b08e-4cdf-8715-4f45d0bbafaf)

パソコンサイズ
![localhost_3000_reversi_](https://github.com/user-attachments/assets/bf1ce788-dabf-4d3d-a25a-3844fde9f86c)


また、menuのリセットボタンを機能させました
それに伴い、スキルカード関連のリセットも改修しています
![localhost_3000_reversi_(iPad Pro)](https://github.com/user-attachments/assets/92b4738d-3867-4ddd-ac73-de1d14709775)
